### PR TITLE
fix(dev): replace ghooks with handrolled hook install

### DIFF
--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+Bold="\e[1m"
+Reset="\e[0m"
+BlackBg="\e[30m"
+Green="\e[32m"
+Yellow="\e[33m"
+Red="\e[91m"
+if [[ -x ./node_modules/.bin/eslint ]]
+then
+	if ./node_modules/.bin/eslint .
+	then
+		printf "\n${BlackBg}${Green}Lint passed, honeybunch. Committing...${Reset}\n"
+	else
+		 printf "${BlackBg}${Red}Lint failed. Aborted commit.${Reset}\n\n"
+		exit 1
+	fi
+else
+	printf "\n${BlackBg}${Yellow}CANNOT LINT BECAUSE LOCAL ESLINT IS NOT INSTALLED!!! Committing anyway, but run \`npm install\`, pal.${Reset}\n\n";
+fi

--- a/hooks/pre-push.sh
+++ b/hooks/pre-push.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+printf "\nRunning npm test before push..."
+npm test

--- a/install-hooks.js
+++ b/install-hooks.js
@@ -1,0 +1,55 @@
+const path = require('path');
+const fs = require('fs');
+const knownHooks = [
+  'applypatch-msg',
+  'pre-applypatch',
+  'post-applypatch',
+  'pre-commit',
+  'prepare-commit-msg',
+  'commit-msg',
+  'post-commit',
+  'pre-rebase',
+  'post-checkout',
+  'post-merge',
+  'pre-receive',
+  'update',
+  'post-receive',
+  'post-update',
+  'pre-auto-gc',
+  'post-rewrite',
+  'pre-push'
+];
+const basename = (n) => path.basename(n, '.sh');
+const isHook = (n) => knownHooks.indexOf(basename(n)) !== -1;
+const newHooks = (n) => path.join(__dirname, `hooks/${n || ''}`);
+const hooks = (n) => path.join(__dirname, `.git/hooks/${n || ''}`);
+const isGHook = (hook) => isHook(hook) &&
+  fs.readFileSync(hook, 'utf-8').indexOf('#!/usr/bin/env node') === 0;
+
+const toDisable = fs.readdirSync(hooks()).map(hooks).filter(isGHook);
+const disableHook = (hook) => {
+  fs.renameSync(hook, `${hook}.old-ghook`);
+  process.stdout.write(` ${basename(hook)} `);
+};
+if (toDisable.length > 0) {
+  process.stdout.write(`${toDisable.length} old ghooks to disable...`);
+  toDisable.forEach(disableHook);
+  process.stdout.write('Done!\n');
+}
+
+const toAdd = fs.readdirSync(newHooks()).filter(isHook);
+const addHook = (name) => {
+  const newHook = newHooks(name);
+  const hookName = basename(name);
+  const hook = hooks(hookName);
+  fs.writeFileSync(hook, fs.readFileSync(newHook));
+  fs.chmodSync(hook, '744');
+  process.stdout.write(` ${hookName} `);
+};
+
+if (toAdd.length > 0) {
+  process.stdout.write(`${toAdd.length} hooks to install...`);
+  toAdd.forEach(addHook);
+  process.stdout.write('Done!\nHooks installed. Write good codes, errbody!\n');
+}
+

--- a/package.json
+++ b/package.json
@@ -11,12 +11,8 @@
     "start": "cross-env NODE_ENV=production node app.js",
     "dev": "cross-env NODE_ENV=development node app.js",
     "lint": "eslint .",
-    "test": "./node_modules/.bin/istanbul test _mocha -- -R spec"
-  },
-  "config": {
-    "ghooks": {
-      "pre-commit": "eslint ."
-    }
+    "test": "istanbul test _mocha -- -R spec",
+    "postinstall": "node ./install-hooks.js"
   },
   "dependencies": {
     "@slack/client": "^3.5.1",
@@ -36,7 +32,6 @@
     "eslint-plugin-promise": "^2.0.0",
     "eslint-plugin-react": "^5.2.2",
     "eslint-plugin-standard": "^2.0.0",
-    "ghooks": "^1.3.2",
     "istanbul": "^0.4.4",
     "mocha": "^2.5.3",
     "nock": "^8.0.0",


### PR DESCRIPTION
due to [an outstanding issue with SourceTree](https://answers.atlassian.com/questions/140339/sourcetree-hook-failing-because-paths-don-t-seem-to-be-set-correctly) and [known weirdness](https://github.com/gtramontina/ghooks/issues/40) with the `ghooks` module i used to install the git hooks, they doesn't work reliably if you're using anything but command-line git. so i handrolled this! 

once this is merged and pulled to your local, you can run `npm postinstall` to remove the old, bad hooks, and install the new, extra spicy ones. they run `npm run lint` on commit, and `npm test` on push!

as always, you can `git commit --no-verify` to bypass, but i did not put this in the log messages, because we shouldn't make that a habit.