### PR TITLE
Remove platform.config file from .ebextensions

### DIFF
--- a/.ebextensions/platform.config
+++ b/.ebextensions/platform.config
@@ -1,4 +1,0 @@
-option_settings:
-  - namespace:  aws:elasticbeanstalk:container:nodejs
-    option_name: NodeVersion
-    value: "4.4.6"


### PR DESCRIPTION
According to the docs, we should remove the NodeVersion option before
updating the environment to a new major version. We probably won't need
to set this explicitly after the upgrade.

https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.nodejs
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-specific.html#command-options-nodejs